### PR TITLE
Fill taskbar on clicking Apply, if the taskbar should be filled per user's settings

### DIFF
--- a/RoundedTB/MainWindow.xaml.cs
+++ b/RoundedTB/MainWindow.xaml.cs
@@ -393,13 +393,13 @@ namespace RoundedTB
                 foreach (Types.Taskbar taskbar in taskbarDetails)
                 {
                     int isFullTest = taskbar.TrayRect.Left - taskbar.AppListRect.Right;
-                    if (!activeSettings.IsDynamic || (isFullTest <= taskbar.ScaleFactor * 25 && isFullTest > 0 && taskbar.TrayRect.Left != 0))
-                    {
-                        Taskbar.UpdateSimpleTaskbar(taskbar, activeSettings);
-                    }
-                    else if (Taskbar.TaskbarShouldBeFilled(taskbar.TaskbarHwnd, activeSettings))
+                    if (Taskbar.TaskbarShouldBeFilled(taskbar.TaskbarHwnd, activeSettings))
                     {
                         Taskbar.ResetTaskbar(taskbar, activeSettings);
+                    }
+                    else if (!activeSettings.IsDynamic || (isFullTest <= taskbar.ScaleFactor * 25 && isFullTest > 0 && taskbar.TrayRect.Left != 0))
+                    {
+                        Taskbar.UpdateSimpleTaskbar(taskbar, activeSettings);
                     }
                     else
                     {

--- a/RoundedTB/MainWindow.xaml.cs
+++ b/RoundedTB/MainWindow.xaml.cs
@@ -397,6 +397,10 @@ namespace RoundedTB
                     {
                         Taskbar.UpdateSimpleTaskbar(taskbar, activeSettings);
                     }
+                    else if (Taskbar.TaskbarShouldBeFilled(taskbar.TaskbarHwnd, activeSettings))
+                    {
+                        Taskbar.ResetTaskbar(taskbar, activeSettings);
+                    }
                     else
                     {
                         Taskbar.UpdateDynamicTaskbar(taskbar, activeSettings);


### PR DESCRIPTION
If the user choose "Fill taskbar when maximized", apply, enable "Dynamic Mode" and click Apply again; it would cause the taskbar to not properly update, resulting in behaviors like the task list and tray area would become too wide or too narrow.
![Task list being too wide](https://user-images.githubusercontent.com/29563098/143400210-f5548294-f2e9-4d11-814d-1bbc52694de3.png)
![Tray being too narrow](https://user-images.githubusercontent.com/29563098/143400301-ea4f4ae1-d5a1-47c5-a3b1-e5df9ca0dac9.png)
